### PR TITLE
Updating GitHub Workflow to include cfn_nag version in commit message

### DIFF
--- a/.github/scripts/update_cfn_nag_formula_version.sh
+++ b/.github/scripts/update_cfn_nag_formula_version.sh
@@ -18,3 +18,6 @@ CFN_NAG_SHA256=$(curl -L -s $CFN_NAG_URL/tarball/v$CFN_NAG_VERSION | shasum -a 2
 sed -i "s#^\(  url\) .*#\1 \"$CFN_NAG_URL/tarball/v$CFN_NAG_VERSION\"#" Formula/cfn-nag.rb
 sed -i "s/^\(  version\) .*/\1 \"$CFN_NAG_VERSION\"/" Formula/cfn-nag.rb
 sed -i "s/^\(  sha256\) .*/\1 \"$CFN_NAG_SHA256\"/" Formula/cfn-nag.rb
+
+# Set cfn_nag version as a GitHub Workflow output
+echo "::set-output name=cfn_nag_version::v${CFN_NAG_VERSION}"

--- a/.github/workflows/cfn_nag-updater.yml
+++ b/.github/workflows/cfn_nag-updater.yml
@@ -20,6 +20,7 @@ jobs:
           git config --global user.email "homebrew-tap@stelligent.com"
           git config --global user.name "stelligent-homebrew-tap-updater"
       - name: Update versions and sha256
+        id: update
         run: |
           bash ./.github/scripts/update_cfn_nag_formula_version.sh
           rm -rf cfn_nag
@@ -29,5 +30,5 @@ jobs:
         run: |
           git diff
           git add .
-          git commit --allow-empty -m "auto-update cfn_nag version and sha256"
+          git commit --allow-empty -m "auto-update cfn_nag version (${{ steps.update.outputs.cfn_nag_version }}) and sha256"
           git push


### PR DESCRIPTION
### Description
Updating GitHub Workflow to include cfn_nag version in commit message.

**Before**
`auto-update cfn_nag version and sha256`

**After**
`auto-update cfn_nag version (v0.5.1) and sha256`

### Testing
1. Deployed the workflow in my personal fork and triggered it via curl call on the command line.
`curl -XPOST -u "cfn_nag-bot:XXXXX" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/pshelby/homebrew-tap/dispatches --data '{"event_type": "build_application"}'`